### PR TITLE
A couple updates

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -20,7 +20,7 @@
                   [org.fusesource.jansi/jansi       "1.11"]
                   [us.bpsm/edn-java                 "0.4.6"]
                   [com.jcabi/jcabi-manifests        "1.1"]
-                  [org.zeromq/jeromq                "0.3.5"]
+                  [org.zeromq/jeromq                "0.4.0"]
                   [jline                            "2.12.1"]])
 
 (require '[adzerk.bootlaces         :refer :all]

--- a/src/alda/AldaRequestOptions.java
+++ b/src/alda/AldaRequestOptions.java
@@ -6,4 +6,5 @@ public class AldaRequestOptions {
   public String from;
   public String to;
   public String history;
+  public String jobId;
 }

--- a/src/alda/AldaResponse.java
+++ b/src/alda/AldaResponse.java
@@ -11,6 +11,7 @@ public class AldaResponse {
   public boolean pending;
   public String signal;
   public String body;
+  public String jobId;
   public AldaScore score;
   public byte[] workerAddress;
   public boolean noWorker;


### PR DESCRIPTION
Hey @jgkamat,

I was playing around with the server code and ended up making a couple of changes to the client code too, based on top of your branch.

- Updated JeroMQ dependency to 0.4.0 -- this is mainly for consistency with changes I'm making to the server (I updated the dependency there too), but JeroMQ 0.4.0 also includes some bug fixes and the ability to create a Poller whose resources are managed through the context.

- I just pushed alda-server-clj 0.2.0, which has a "job ID" system to help solve https://github.com/alda-lang/alda-server-clj/issues/8, i.e. the issues with requests happening out of sync, causing the worker to send back the wrong score and the client to display the wrong instruments in the REPL prompt. With the changes here, the client sends a job ID on every play/play-status request it makes, and ignores responses from the server if the job ID doesn't match.

- I tweaked the ZMQ request-sending code a bit. It's almost the same as what you did with `cleanupSocket()`, but just written a little differently and incorporating the reusable Poller object. (Every time a socket is destroyed, we have to unregister it with the poller, and then when we create a new socket, we have to register it with the poller.)

- I also bumped up the default retry parameters so that instead of making 3 requests and waiting 2.5 seconds in between each retry, we make 15 requests and wait 500 ms in between each retry. This should make it feel like we're getting responses faster because we're retrying more often.

Some things that still need to be improved:

- We're still only sending one `play` request with a 3000 ms timeout, which is a limitation of the server. This is not great, because if the `play` request fails to get a response (e.g. if it takes more than 3000 ms for the worker to respond, or if there are network issues), then all we can do is print an error and the user has to try again manually. We can't retry automatically because we only want the score to play once.

  The new "job ID" system _almost_ allows us to send multiple requests with the same job ID and not worry about the score playing more than once, but the problem is that the server distributes requests to multiple workers, and the job IDs aren't coordinated amongst the workers, so each worker will play the score once.

  I have some ideas on how to improve this -- I'll keep tinkering with it.

* Fixing https://github.com/alda-lang/alda-client-java/issues/12 will make the REPL experience feel a little nicer.